### PR TITLE
:hamster: Add protocol to websites that have none

### DIFF
--- a/app/lib/mappers/mapContact.js
+++ b/app/lib/mappers/mapContact.js
@@ -1,0 +1,15 @@
+const phoneNumberParser = require('../phoneNumberParser');
+const addProtocol = require('../urlUtils').addProtocol;
+
+function mapContact(rawContact, website) {
+  const result = { website: addProtocol(website) };
+  const contact = rawContact;
+  if (contact) {
+    result.telephone = phoneNumberParser(contact.telephone);
+    result.fax = phoneNumberParser(contact.fax);
+    result.email = contact.email;
+  }
+  return result;
+}
+
+module.exports = mapContact;

--- a/app/lib/mappers/mapOverview.js
+++ b/app/lib/mappers/mapOverview.js
@@ -1,12 +1,12 @@
-const utils = require('../utils');
-const urlParser = require('../urlParser');
-const phoneNumberParser = require('../phoneNumberParser');
-const mapOpeningTimes = require('./mapOpeningTimes');
 const mapAddress = require('./mapAddress');
-const mapLocation = require('./mapLocation');
-const mapGpCounts = require('./mapGpCounts');
+const mapContact = require('./mapContact');
 const mapDoctors = require('./mapDoctors');
+const mapGpCounts = require('./mapGpCounts');
+const mapLocation = require('./mapLocation');
+const mapOpeningTimes = require('./mapOpeningTimes');
 const properCapitalize = require('../properCapitalize');
+const urlParser = require('../urlParser');
+const utils = require('../utils');
 
 function matchAltHref(link) {
   return utils.getAttribute(link, 'rel') === 'alternate';
@@ -19,17 +19,6 @@ function getChoicesId(links) {
 
 function getAcceptingNewPatients(content) {
   return utils.getBooleanAttribute(content.newPatients, 'accepting');
-}
-
-function getContact(content) {
-  const result = { website: content.website };
-  const contact = content.contact;
-  if (contact) {
-    result.telephone = phoneNumberParser(contact.telephone);
-    result.fax = phoneNumberParser(contact.fax);
-    result.email = contact.email;
-  }
-  return result;
 }
 
 function mapOverview(rawOverview) {
@@ -55,7 +44,7 @@ function mapOverview(rawOverview) {
     odsCode: content.odsCode,
     address: mapAddress(content.address),
     location: mapLocation(content.geographicCoordinates),
-    contact: getContact(content),
+    contact: mapContact(content.contact, content.website),
     openingTimes: mapOpeningTimes.all(content.openingTimes),
     gpCounts: mapGpCounts(content.gpcounts),
     doctors: mapDoctors(content.doctors),

--- a/app/lib/urlUtils.js
+++ b/app/lib/urlUtils.js
@@ -1,0 +1,14 @@
+const url = require('url');
+
+function addProtocol(website) {
+  if (website) {
+    return (url.parse(website).protocol)
+    ? website
+    : `http://${website}`;
+  }
+  return website;
+}
+
+module.exports = {
+  addProtocol,
+};

--- a/test/resources/overview-no-website-protocol.json
+++ b/test/resources/overview-no-website-protocol.json
@@ -1,0 +1,202 @@
+{
+    "feed": {
+        "$": {
+            "xmlns": "http://www.w3.org/2005/Atom"
+        },
+        "title": {
+            "_": "NHS Choices - Croft Medical Centre - Overview",
+            "$": {
+                "type": "text"
+            }
+        },
+        "id": "http://v1.syndication.nhschoices.nhs.uk/organisations/gppractices/17307/overview",
+        "rights": {
+            "_": "© Crown Copyright 2009",
+            "$": {
+                "type": "text"
+            }
+        },
+        "updated": "2015-12-15T14:45:46Z",
+        "category": {
+            "$": {
+                "term": "Overview"
+            }
+        },
+        "logo": "http://www.nhs.uk/nhscwebservices/documents/logo1.jpg",
+        "author": {
+            "name": "NHS Choices",
+            "uri": "http://www.nhs.uk",
+            "email": "webservices@nhschoices.nhs.uk"
+        },
+        "link": [
+            {
+                "$": {
+                    "rel": "self",
+                    "type": "application/xml",
+                    "title": "NHS Choices - Croft Medical Centre - Overview",
+                    "href": "http://v1.syndication.nhschoices.nhs.uk/organisations/gppractices/17307/overview?apikey=apikey"
+                }
+            },
+            {
+                "$": {
+                    "rel": "alternate",
+                    "title": "NHS Choices - Croft Medical Centre - Overview",
+                    "href": "http://www.nhs.uk/Services/GP/Overview/DefaultView.aspx?id=36931"
+                }
+            }
+        ],
+        "tracking": {
+            "_": "<img style=\"border: 0; width: 1px; height: 1px;\" alt=\"\" src=\"http://statse.webtrendslive.com/dcss9yzisf9xjyg74mgbihg8p_8d2u/njs.gif?dcsuri=/organisations%2fgppractices%2f17307%2foverview&amp;wt.js=no&amp;wt.cg_n=syndication\"/>",
+            "$": {
+                "xmlns": "http://syndication.nhschoices.nhs.uk/services"
+            }
+        },
+        "complete": {
+            "$": {
+                "xmlns": "http://purl.org/syndication/history/1.0"
+            }
+        },
+        "entry": {
+            "id": "http://v1.syndication.nhschoices.nhs.uk/organisations/gppractices/17307/overview",
+            "title": {
+                "_": "Croft Medical Centre - Overview",
+                "$": {
+                    "type": "text"
+                }
+            },
+            "published": "2015-12-15T14:45:46Z",
+            "updated": "2015-12-15T14:45:46Z",
+            "link": [
+                {
+                    "$": {
+                        "rel": "self",
+                        "title": "Croft Medical Centre - Overview",
+                        "href": "http://v1.syndication.nhschoices.nhs.uk/organisations/gppractices/17307/overview?apikey=apikey"
+                    }
+                },
+                {
+                    "$": {
+                        "rel": "alternate",
+                        "title": "Croft Medical Centre - Overview",
+                        "href": "http://www.nhs.uk/Services/GP/Overview/DefaultView.aspx?id=36931"
+                    }
+                }
+            ],
+            "content": {
+                "$": {
+                    "type": "application/xml"
+                },
+                "overview": {
+                    "$": {
+                        "xmlns:s": "http://syndication.nhschoices.nhs.uk/services"
+                    },
+                    "name": {
+                        "_": "Croft Medical Centre",
+                        "$": {
+                            "indexLetter": "C"
+                        }
+                    },
+                    "odsCode": "M89012",
+                    "parentOrganisation": {
+                        "name": "NHS Solihull CCG",
+                        "uri": "http://v1.syndication.nhschoices.nhs.uk/organisations/clinicalcommissioninggroups/463005?apikey=apikey"
+                    },
+                    "address": {
+                        "addressLine": [
+                            "Croft Medical centre",
+                            "1 Pomeroy Way",
+                            "Chelmsley Wood",
+                            "Birmingham",
+                            "West Midlands"
+                        ],
+                        "postcode": "B37 7WB"
+                    },
+                    "contact": {
+                        "$": {
+                            "type": "General"
+                        },
+                        "telephone": "0121 270 7180",
+                        "fax": "0121 770 0130"
+                    },
+                    "website": "www.craigcroftmedicalcentre.co.uk/",
+                    "geographicCoordinates": {
+                        "longitude": "-1.72773551940918",
+                        "latitude": "52.4778633117676"
+                    },
+                    "newPatients": {
+                        "$": {
+                            "accepting": "True"
+                        },
+                        "statusText": "We are currently accepting new patients",
+                        "registrationText": "Please register during reception hours",
+                        "registrationFormUrl": "http://www.nhs.uk/Servicedirectories/Documents/GMS1.pdf",
+                        "registrationFormText": "Download registration form",
+                        "catchmentAreaUrl": "http://www.nhs.uk/Services/GP/MapsAndDirections/DefaultView.aspx?id=36931",
+                        "catchmentAreaText": "View catchment area",
+                        "faqUrl": "http://www.nhs.uk/Services/GP/PatientInformation/DefaultView.aspx?id=36931",
+                        "faqText": "More patient information",
+                        "patientAdvice": "\r\n\t<p>Need advice on how to choose a GP?<br/><a href=\"http://www.nhs.uk/choiceintheNHS/Yourchoices/GPchoice/Documents/rcgp_iyp_full_booklet_web_version.pdf\">\r\n\tView a guide by the Royal College of GPs</a></p>\r\n\t"
+                    },
+                    "overviewLastUpdated": "2015-12-15 14:42:41Z",
+                    "doctors": {
+                        "doctor": [
+                            "Dr Michael Robert Bosworth",
+                            "Dr Oliver Denton",
+                            "Dr Alicia Baker",
+                            "Dr Alison Dorothy Hales",
+                            "Dr Shazli Musarat Noor Khan",
+                            "Dr Srividya Balasubramanian"
+                        ]
+                    },
+                    "gpcounts": {
+                        "gpcount": [
+                            {
+                                "_": "2",
+                                "$": {
+                                    "type": "male"
+                                }
+                            },
+                            {
+                                "_": "4",
+                                "$": {
+                                    "type": "female"
+                                }
+                            }
+                        ]
+                    },
+                    "isEpsEnabled": "true",
+                    "articles": {
+                        "article": {
+                            "articleTitle": "Surgery relocation",
+                            "articleDescription": "<p>The surgery&nbsp;has now relocated to it's permanent new home&nbsp; in purpose built premises at 1 Pomeroy Way, just a short walk from the temporary accomodation and opposite our original location on Craig Croft.The telephone number is still&nbsp;0121 270 7180.</p>\r\n<p>&nbsp;</p>",
+                            "articleModifiedDate": "15/12/2015 14:42:41"
+                        }
+                    },
+                    "overviewKeyFacts": {
+                        "keyFacts": {
+                            "keyFact": [
+                                {
+                                    "question": "Registered list size",
+                                    "value": "10968",
+                                    "text": "patients"
+                                },
+                                {
+                                    "question": "Friends and Family test score - GP",
+                                    "text": "Patients recommend this practice. [Value2] responses."
+                                }
+                            ]
+                        },
+                        "moreInformation": {
+                            "url": "http://www.nhs.uk/Scorecard/Pages/GpFacts.aspx",
+                            "text": "More information about this data"
+                        },
+                        "performance": {
+                            "url": "http://www.nhs.uk/Services/GP/Performance/DefaultView.aspx?id=36931",
+                            "text": "More on how we perform"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/unit/mapOverview.js
+++ b/test/unit/mapOverview.js
@@ -5,6 +5,7 @@ const rawOverviewNoOpeningTimes = require('../resources/overview-no-opening-time
 const rawOverviewNoChoicesId = require('../resources/overview-no-choicesId.json');
 const rawOverviewNoName = require('../resources/overview-no-name.json');
 const rawOverviewNoContacts = require('../resources/overview-no-contacts.json');
+const rawOverviewNoWebsiteProtocol = require('../resources/overview-no-website-protocol.json');
 
 const expect = chai.expect;
 
@@ -36,6 +37,12 @@ describe('overview mapper', () => {
     expect(overview.doctors).to.exist;
     /* eslint-enable no-unused-expressions */
     expect(overview.doctors.length).to.equal(6);
+  });
+
+  it('should add an http protocol to website when there is no protocol', () => {
+    const overview = mapOverview(rawOverviewNoWebsiteProtocol);
+
+    expect(overview.contact.website).to.be.equal('http://www.craigcroftmedicalcentre.co.uk/');
   });
 
   it('should gracefully handle missing opening times', () => {

--- a/test/unit/urlUtils.js
+++ b/test/unit/urlUtils.js
@@ -1,0 +1,29 @@
+const chai = require('chai');
+const urlUtils = require('../../app/lib/urlUtils');
+
+const expect = chai.expect;
+
+describe('urlUtils', () => {
+  describe('addProtocol', () => {
+    it('should add http protocol to website when it has no protocol', () => {
+      const protocollessUrl = 'www.someplace.known';
+      const result = urlUtils.addProtocol(protocollessUrl);
+
+      expect(result).to.be.equal(`http://${protocollessUrl}`);
+    });
+
+    it('should return no website when there is not one supplied', () => {
+      const result = urlUtils.addProtocol(undefined);
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(result).to.be.undefined;
+    });
+
+    it('should return the website unaltered when it has a protocol', () => {
+      const urlWithProtocol = 'http://protocol.included.com';
+      const result = urlUtils.addProtocol(urlWithProtocol);
+
+      expect(result).to.be.equal(urlWithProtocol);
+    });
+  });
+});


### PR DESCRIPTION
This is to prevent an explosion of fixes happening within the consuming apps of the data generated by this app. See https://github.com/nhsuk/profiles/blob/master/app/lib/contactsMapper.js for the currently known about example where this logic is being used. When this is merged and a new data set has been generated I'll be able to remove that logic.